### PR TITLE
Update outdated question grammar

### DIFF
--- a/app/views/question.html
+++ b/app/views/question.html
@@ -8,7 +8,7 @@
     <h4>{{ question.title }}</h4>
     <p ng-bind-html="question.answer"></p>
     <p ng-if="isOutDated(question)" class="note"><em>
-      This question wasn't updated in a month.
+      This question hasn't been updated in a month.
       If in doubt visit us on <a href="http://hood.ie/chat/">IRC</a> or ping us
       on Twitter (<a href="http://twitter.com/hoodiehq">@hoodiehq</a>).
     </em></p>


### PR DESCRIPTION
I've update the `isOutdated` view from:

`This wasn't updated in a month`

to:

`This hasn't been updated in a month`

I think the second line reads better and gives a better idea of the FAQ app as a thing that is regularly updated. As well as not reading as well at it can, the word **wasn't** suggests the app is becoming defunct, which it certainly isn't!