### PR TITLE
fix(footer): add right link to impressum

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -106,7 +106,7 @@ and we’d love to have you on board: http://hood.ie/contribute
        <section class="cb sitemap">
         <ul class="sitemap-list l">
           <li><a href="https://github.com/hoodiehq/faq/issues/new">Ask a question</a> | </li>
-          <li><a href="http://thehoodiefirm.com/impressum.html">Impressum</a></li>
+          <li><a href="http://hood.ie/impressum/">Impressum</a></li>
         </ul>
         </section>
       </div>


### PR DESCRIPTION
The original link to the impressum ends in a 404, I added a link to what I think is the right one :)