### PR TITLE
fix(accessibility): add hidden label for search field

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -19,6 +19,11 @@
   background-image: none;
 }
 
+.faq b {
+  position: absolute;
+  left: -999em;
+}
+
 .faq input#search {
   border: solid #CCC;
   border-width: 0 0 1px 0;

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -5,7 +5,8 @@
     </a>
   </h2>
   <section class="cb">
-    <input id="search" type="search" ng-model="searchTerm" placeholder="How can we help you today?">
+    <label for="search"><b>Search for an answer</b></label>
+    <input role="search" id="search" type="search" ng-model="searchTerm" placeholder="How can we help you today?">
   </section>
 
   <section ng-show="categories" class="box">


### PR DESCRIPTION
**Problem**:
When running an accessibility audit on the app using various tools ([1], [2]), the most common problem is the lack of label for the search field. If you listen to the app using VoiceOver it says "How can we help you today?, search text field". This does not give a good indication to someone using a screenreader what they can search for, and what the search would actually search to return results. As sighted individuals we can assume this through the visual context of where the search box is.

**Solution**:
Commit 5e06d09 does three things:

1. Adds a label linked to the search field that says "Search for an answer"
1. Positions the label offscreen using [this common approach](http://accessibilitytips.com/2008/03/04/positioning-content-offscreen/), it will be read by a screenreader to offer better context to the user, but will not be seen within the browser itself. VoiceOver now reads it as "How can we help you today?, Search for an answer, search text field" which, in my opinion, offers a much better understanding of what you can do on this page.
1. Adds an aria role of `search`

Not only do we now have better accessibility, we increase our HTML validity as it is required that all form fields have a label.

[1]: https://www.npmjs.com/package/a11y
[2]: http://tenon.io