### PR TITLE
fix(accessibility): add offscreen label for logo link

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -52,7 +52,7 @@ and we’d love to have you on board: http://hood.ie/contribute
     <![endif]-->
       <header>
         <section class="nav">
-            <a href="http://hood.ie" class="logo"><img src="images/logo.svg" width="135" alt=""></a>
+            <a href="http://hood.ie" class="logo"><img src="images/logo.svg" width="135" alt=""><b>Hoodie</b></a>
             <nav class="main-nav">
                 <a href="http://hood.ie/intro">Intro</a>
                 <a href="http://hood.ie/contribute">Contribute</a>


### PR DESCRIPTION
**Problem**: All links should have sufficient explanative text as to what it is linking to. VoiceOver currently reads the Hoodie logo as "link slash". If CSS hasn't loaded in (tested by disabling it) then there is just a blank box that can be tabbed to, visually you wouldn't know what it did until you clicked it.

**Solution**: Utilising [the offscreen method](http://accessibilitytips.com/2008/03/04/positioning-content-offscreen/), I have added link text of "Hoodie" so that VoiceOver now reads "Link, Hoodie". When styles are disabled it will now also show the actual Hoodie link instead of having to guess where it goes.

This shouldn't be merged until #101 is as this PR relies on the `.faq b` styling it includes.