### PR TITLE
fix(html5/accessibility): add aria roles to content divs

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,4 +1,4 @@
-<div class="content">
+<div role="main" class="content">
   <h2>
     <a href="/" id="logo-animation">
       Frequently Asked Questions

--- a/app/views/question.html
+++ b/app/views/question.html
@@ -1,4 +1,4 @@
-<div class="content">
+<div role="main" class="content">
   <h2>
     <a href="/" id="logo-animation">
       &#8592; Frequently Asked Questions


### PR DESCRIPTION
This PR switches the `<div>`'s that hold the main page content to `<main>` elements for good HTML semantics. It also adds an aria role of `main` for accessibility purposes.

Does not seem to affect any visuals on the site, so should be save to merge!