### PR TITLE
fix(html semantics/a11y): add nav blocks with aria roles

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -53,7 +53,7 @@ and we’d love to have you on board: http://hood.ie/contribute
       <header>
         <section class="nav">
             <a href="http://hood.ie" class="logo"><img src="images/logo.svg" width="135" alt=""></a>
-            <nav class="main-nav">
+            <nav role="navigation" class="main-nav">
                 <a href="http://hood.ie/intro">Intro</a>
                 <a href="http://hood.ie/contribute">Contribute</a>
                 <a href="http://hood.ie/get-help">Get help</a>
@@ -62,40 +62,46 @@ and we’d love to have you on board: http://hood.ie/contribute
                 <a href="http://hood.ie/animals">Animals</a>
                 <a href="http://hood.ie/contact">Contact</a>
             </nav>
-            <ul class="meta-nav">
-                <li class="meta-nav-list-item"><a href="http://hood.ie/blog/" target="_blank">Blog</a></li>
-                <li class="meta-nav-list-item"><a href="/" class="">Docs</a></li>
-                <!-- <li><a href="#">try</a></li> -->
-                <li class="meta-nav-list-item"><a href="http://faq.hood.ie" target="_blank">FAQ</a></li>
-            </ul>
-            <a href="#" class="menu-button">
-                <span class="menu-button-span"></span>
-            </a>
+            <nav role="navigation">
+              <ul class="meta-nav">
+                  <li class="meta-nav-list-item"><a href="http://hood.ie/blog/" target="_blank">Blog</a></li>
+                  <li class="meta-nav-list-item"><a href="/" class="">Docs</a></li>
+                  <!-- <li><a href="#">try</a></li> -->
+                  <li class="meta-nav-list-item"><a href="http://faq.hood.ie" target="_blank">FAQ</a></li>
+              </ul>
+            </nav>
+            <nav role="navigation">
+              <a href="#" class="menu-button">
+                  <span class="menu-button-span"></span>
+              </a>
+            </nav>
         </section>
         <section>
-            <ul class="sub-nav">
-                <li class="sub-nav-list-item">
-                    <a href="http://docs.hood.ie/en/">Hoodieverse</a>
-                </li>
-                <li class="sub-nav-list-item">
-                    <a href="http://docs.hood.ie/en/start">Let's start</a>
-                </li>
-                <li class="sub-nav-list-item">
-                    <a href="http://docs.hood.ie/en/tutorials">Tutorials</a>
-                </li>
-                <li class="sub-nav-list-item">
-                    <a href="http://docs.hood.ie/en/techdocs">API</a>
-                </li>
-                <li class="sub-nav-list-item">
-                    <a href="http://docs.hood.ie/en/plugins">Plugins</a>
-                </li>
-                <li class="sub-nav-list-item">
-                    <a href="http://docs.hood.ie/en/deployment">Deployment</a>
-                </li>
-                <li class="sub-nav-list-item">
-                    <a href="http://docs.hood.ie/en/community">Community</a>
-                </li>
-            </ul>
+            <nav role="navigation">
+              <ul class="sub-nav">
+                  <li class="sub-nav-list-item">
+                      <a href="http://docs.hood.ie/en/">Hoodieverse</a>
+                  </li>
+                  <li class="sub-nav-list-item">
+                      <a href="http://docs.hood.ie/en/start">Let's start</a>
+                  </li>
+                  <li class="sub-nav-list-item">
+                      <a href="http://docs.hood.ie/en/tutorials">Tutorials</a>
+                  </li>
+                  <li class="sub-nav-list-item">
+                      <a href="http://docs.hood.ie/en/techdocs">API</a>
+                  </li>
+                  <li class="sub-nav-list-item">
+                      <a href="http://docs.hood.ie/en/plugins">Plugins</a>
+                  </li>
+                  <li class="sub-nav-list-item">
+                      <a href="http://docs.hood.ie/en/deployment">Deployment</a>
+                  </li>
+                  <li class="sub-nav-list-item">
+                      <a href="http://docs.hood.ie/en/community">Community</a>
+                  </li>
+              </ul>
+            </nav>
         </section>
     </header>
 


### PR DESCRIPTION
This PR does two things:

1. Surrounds all navigation lists with a `<nav>` block.
1. Adds an ARIA role of `navigation` to each navigation block.

You cannot add a role of `navigation` to a `<ul>` so we must put the `<ul>` within a `<nav>` block, which is also good to for HTML semantics/purity. You can have multiple `<nav>`'s on a page, so this shouldn't be a problem. I also don't see any indication of special CSS styling on the `nav` so this shouldn't bring about any visual changes.