### PR TITLE
feat(noscript): add noscript link to GH issues

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -99,6 +99,14 @@ and we’d love to have you on board: http://hood.ie/contribute
         </section>
     </header>
 
+    <noscript>
+      <div class="content">
+        <h2>
+          <a href="https://github.com/hoodiehq/faq/issues?utf8=%E2%9C%93&q=is%3Aclosed+label%3Aanswered+">Check out the Hoodie FAQs on Github!</a>
+        </h2>
+      </div>
+    </noscript>
+
     <ui-view></ui-view>
 
     <footer>


### PR DESCRIPTION
This is the beginning of fixes for #107. I've added a noscript tag and changed the scope of the angular application to allow us to show a link to the `answered` GitHub issues on this repository.

Users without JS would see the following:

![screen shot 2015-06-18 at 11 58 53](https://cloud.githubusercontent.com/assets/593574/8228715/510b3a5c-15b1-11e5-9997-af50d536d260.png)