### PR TITLE
fix(accessibility): better search labelling

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -5,8 +5,8 @@
     </a>
   </h2>
   <section class="cb">
-    <label for="search"><b>Search for an answer</b></label>
-    <input role="search" id="search" type="search" ng-model="searchTerm" placeholder="How can we help you today?">
+    <label id="search_label" for="search"><b>Search for an answer</b></label>
+    <input aria-labelledby="search_label" role="search" id="search" type="search" ng-model="searchTerm" placeholder="How can we help you today?">
   </section>
 
   <section ng-show="categories" class="box">


### PR DESCRIPTION
You can test VoiceOver in three ways:

1) Tabbing across the elements on a page, this reads all the focusable content link links and such
2) Pressing the down arrow and reading **all** the content on a page
3) Having voiceover read the page for you

In some of these instances (tabbing across elements), the search label was not read out when you focused on the search field. When you use the arrow keys, the hidden label is read out before the search box is.

This change utilised the `aria-labelledby` attribute to make sure that the 'Search for an answer` label is read out when you tab to the search bar. The label is still read out before the search box when you use arrow keys and now read again when you use the arrow keys to search bar (so is read twice), but this is something I do not think there is a way to work around without changing the design of the layout (a good example of a working search bar is http://gov.uk which uses visible labels and JavaScript).

I think this makes our search bar better when read out by a screen reader.